### PR TITLE
Update C/C++ extensions to include cc

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -34,7 +34,7 @@
     { "name": "actionscript", "label": "AS3", "extensions": ["as"] },
     { "name": "batchfile", "label": "Batch File", "extensions": ["bat"] },
     { "name": "sh", "label": "Bash Shell", "extensions": ["sh"] },
-    { "name": "c_cpp", "label": "C/C++", "extensions": ["c", "cpp", "h"] },
+    { "name": "c_cpp", "label": "C/C++", "extensions": ["c", "cpp", "h", "cc"] },
     { "name": "coffee", "label": "CoffeeScript", "extensions": ["coffee"] },
     { "name": "csharp", "label": "C#", "extensions": ["cs"] },
     { "name": "css", "label": "CSS", "extensions": ["css"] },


### PR DESCRIPTION
.cc is a popular extension for C/C++ files. I've been in the Native Client Examples a lot lately and it seems most of those files use the .cc extension. It would be nice if Caret recognized this and I don't think it conflicts with any other possible formats.
