### PR TITLE
Style editor scrollbars with light/dark ui theme

### DIFF
--- a/css/ui.less
+++ b/css/ui.less
@@ -104,7 +104,7 @@
 }
 
 ::-webkit-scrollbar-track {
-    background-color: mix(@foreground, @background, 15%);
+    background-color: transparent;
 }
 
 ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Make scrollbars not as jarring by styling them according to the current ui theme's background and foreground colors.

I tried to make them look quite similar to the default ones in Chrome Canary, though I couldn't get the border around the thumb since I had to use a transparent border to get space around it. This could always be improved later I guess.
