### PR TITLE
Add info about running npm install and starting grunt in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,6 @@ Caret is a serious, graphical programmer's editor running as a Chrome Packaged A
 
 More information, links to Caret in the Chrome Web Store, and an external package file are available at http://thomaswilburn.net/caret. Documentation can be found in the [wiki](https://github.com/thomaswilburn/Caret/wiki).
 
-You can also easily load Caret from source, either to hack around on or to have the absolute bleeding edge. Clone this repo to your local machine, then visit `chrome://extensions` and enable Developer Mode. Then click the button marked "Load unpacked extension..." and select the directory containing Caret's manifest.json.
+You can also easily load Caret from source, either to hack around on or to have the absolute bleeding edge. Clone this repo to your local machine, run npm install, and start grunt. Visit `chrome://extensions` and enable Developer Mode. Then click the button marked "Load unpacked extension..." and select the directory containing Caret's manifest.json.
 
 If you use Caret and would like to show your appreciation, please consider donating to the [EFF's Fund to End Software Patents](https://my.fsf.org/donate/directed-donations/esp). You can also give a gift through [Gittip](https://www.gittip.com/thomaswilburn/).


### PR DESCRIPTION
Loading Caret from source requires running npm install and starting grunt to get LESS files processed into CSS.
