### PR TITLE
Only trim whitespace between non-whitespace and newline (Issue #158)

### DIFF
--- a/js/aceBindings.js
+++ b/js/aceBindings.js
@@ -133,7 +133,7 @@ define([
         var range = selection.getLineRange(i);
         range.end.row = range.start.row;
         range.end.column = line.length;
-        line = line.replace(/\s+$/, "");
+        line = line.replace(/(\S)\s+$/, "$1");
         doc.replace(range, line);
       });
       if (c) c();


### PR DESCRIPTION
This prevents trimming lines that only have whitespace.
