### PR TITLE
Added "wrap" function:

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -21,6 +21,7 @@
   { "label": "Select Line", "command": "sublime:expand-to-line" },
   { "label": "Select Paragraph", "command": "sublime:expand-to-paragraph" },
   { "label": "Select to Matching", "command": "sublime:expand-to-matching" },
+  { "label": "Wrap Paragraph to Print Margin", "command": "sublime:wrap" },
   { "label": "Word Count", "command": "editor:word-count" },
   
   { "label": "Find", "command": "ace:command", "argument": "find" },

--- a/config/keys.json
+++ b/config/keys.json
@@ -27,6 +27,7 @@
   
   //Sublime compatibility
   "Ctrl-L": "sublime:expand-to-line",
+  "Alt-Q": "sublime:wrap",
   "Ctrl-D": { "ace": "selectMoreAfter" },
   "Ctrl-P": { "command": "palette:open" },
   "Ctrl-Shift-P": { "command": "palette:open", "argument": "command" },

--- a/config/menus.json
+++ b/config/menus.json
@@ -23,6 +23,7 @@
       { "label": "Select Line", "command": "sublime:expand-to-line" },
       { "label": "Select Paragraph", "command": "sublime:expand-to-paragraph" },
       { "label": "Select to Matching", "command": "sublime:expand-to-matching" },
+      { "label": "Wrap Paragraph to Print Margin", "command": "sublime:wrap" },
       "divider",
       { "label": "Find", "command": "ace:command", "argument": "find" },
       { "label": "Find/Replace", "command": "ace:command", "argument": "replace" },


### PR DESCRIPTION
"Wrap" will find the first blank line before and after a selection and use this range as a paragraph to wrap. The paragraph is split into words (space delimited) and the length of each word is used to make sure that a single line will not exceed the print margin (ruler) width. If a single word exceeds that width, the word is split.
