### PR TITLE
More complete Ace-style key binding and Mac-style key symbol display support

### DIFF
--- a/config/keys.json
+++ b/config/keys.json
@@ -7,8 +7,6 @@
   "Ctrl-N": "session:new-file",
   "Ctrl-Tab": "session:change-tab",
   "Ctrl-Shift-Tab": { "command": "session:change-tab", "argument": -1 },
-  "Ctrl-Z": {"command": "ace:command", "argument": "undo" },
-  "Ctrl-Shift-Z": { "command": "ace:command", "argument": "redo" },
   
   //Chromebook fixes
   "Ctrl-Up": { "ace": "addCursorAbove" },

--- a/js/ui/keys.js
+++ b/js/ui/keys.js
@@ -46,6 +46,27 @@ define([
           .replace(/-([A-Z]+)$/, "-Shift-$1")
           .replace(/-([a-z]+)$/, function(match) { return match.toUpperCase() });
       }
+        
+      //convert to Ace-style binding (use Command rather than Cmd)
+      key = key
+        .replace("Cmd-", "Command-")
+        .replace("Opt-", "Option-")
+        .replace("Control-", "Ctrl-");
+
+      //Conversion between Mac and Windows
+      if(useragent.isMac) {
+          key = key
+            .replace("Alt", "Option")
+            .replace("Ctrl", "Command")
+          //use MacCtrl to replace real Control on Mac
+            .replace("MacCtrl", "Ctrl");
+      } else {
+          key = key
+            .replace("Option", "Alt")
+            .replace("Command", "Ctrl")
+            .replace("MacCtrl", "Ctrl");
+      }
+          
       converted[key.toLowerCase()] = value;
     }
     return converted;
@@ -53,7 +74,7 @@ define([
   
   //need to auto-bind Ace keys, remove Ace conflicts
   var bindAce = function() {
-    var handler = new AceCommandManager("win", defaultAceCommands);
+    var handler = new AceCommandManager(useragent.isMac ? "mac" : "win", defaultAceCommands);
     var bindings = normalizeKeys(Settings.get("keys"));
     var ckb = handler.commandKeyBinding;
     for (var k in bindings) {
@@ -88,9 +109,9 @@ define([
     }
     var prefixes = [];
     //Make Command key on Mac works as Ctrl key
-    if (useragent.isMac && e.metaKey) prefixes.push("Ctrl");
+    if (useragent.isMac && e.metaKey) prefixes.push("Command");
     if (e.ctrlKey) prefixes.push("Ctrl");
-    if (e.altKey) prefixes.push("Alt");
+    if (e.altKey) prefixes.push(useragent.isMac ? "Option" : "Alt");
     if (e.shiftKey) prefixes.push("Shift");
     var combo = prefixes.length ? prefixes.join("-") + "-" + char : char;
     combo = combo.toLowerCase();


### PR DESCRIPTION
The following features are added:
1. Convert keys between Windows and Mac
2. Automaticly convert "Ctrl" in keys.json to "Command" on mac,  use "MacCtrl" to present "Control" key on Mac.
3. Use Ace-style key definition and works with default Ace key bindings.
4. Mac-style shortcut symbol display.

It works on Mac, please test on other platform.
