### PR TITLE
Add Sublime compatibility for shift Line Up/Down.

### DIFF
--- a/config/keys.json
+++ b/config/keys.json
@@ -43,6 +43,8 @@
   "Ctrl-=": { "command": "editor:adjust-zoom", "argument": 1 },
   "Ctrl-0": { "command": "editor:default-zoom" },
   "Ctrl-J": { "ace": "joinlines" },
+  "Ctrl-Shift-Up": { "ace": "movelinesup" },
+  "Ctrl-Shift-Down": { "ace": "movelinesdown" },
   
   //dev mode
   "Ctrl-.": { "command": "app:show-prompt" }


### PR DESCRIPTION
Mapped the command `movelinesup` and `movelinesdown` that are mapped by default in Ace to _Alt+Up_ and _Alt+Down_ to Sublime default key mapping _Ctrl+Shift+Up_ and _Ctrl+Shift+Down_.
