### PR TITLE
Find All Feature

### DIFF
--- a/js/ace/ext-searchbox.js
+++ b/js/ace/ext-searchbox.js
@@ -288,7 +288,6 @@ var SearchBox = function(editor, range, showReplaceForm) {
             if (sb.activeInput == sb.replaceInput)
                 sb.replace();
             sb.findAll();
-            sb.hide();
         },
         "Tab": function(sb) {
             (sb.activeInput == sb.replaceInput ? sb.searchInput : sb.replaceInput).focus();
@@ -355,6 +354,7 @@ var SearchBox = function(editor, range, showReplaceForm) {
         dom.setCssClass(this.searchBox, "ace_nomatch", noMatch);
         this.editor._emit("findSearchBox", { match: !noMatch });
         this.highlight();
+        this.hide();
     };
     this.replace = function() {
         if (!this.editor.getReadOnly())


### PR DESCRIPTION
Added a find all feature which works similarly to Sublime's find all. In the Ctrl-F searchbox there is an additional button which says "All", pressing this button or hitting "Alt+Enter" will highlight all options in the text. This will also close the find search box.

This functionality mirrors Sublime Text's "Find All" exactly. It was one of my favorite features from there, and I was dissapointed to not see it in Caret. 

How the new search box looks, the only change is the addition of the "All" button:
![screenshot 2014-09-17 at 2 24 38 am](https://cloud.githubusercontent.com/assets/6777709/4299221/67cee2ee-3e33-11e4-927d-aeab520c1d25.png)

After hitting "Alt+Enter" or the "All" button, all the results are highlighted like so:
![screenshot 2014-09-17 at 2 26 58 am](https://cloud.githubusercontent.com/assets/6777709/4299272/d0fb2f5c-3e33-11e4-840f-877df33f3e71.png)

All the results are now selected, and typing will replace them all with individual instances of what was typed.
