### PR TITLE
Added rkt,lsp, and lisp to lisp extentions

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -62,7 +62,7 @@
     { "name": "julia", "label": "Julia", "extensions": [] },
     { "name": "latex", "label": "LaTeX", "extensions": [] },
     { "name": "less", "label": "LESS", "extensions": ["less"] },
-    { "name": "lisp", "label": "Lisp", "extensions": [] },
+    { "name": "lisp", "label": "Lisp", "extensions": ["rkt","lsp","lisp"] },
     { "name": "lsl", "label": "LSL", "extensions": ["lsl"] },
     { "name": "lua", "label": "Lua", "extensions": ["lua", "love"] },
     { "name": "makefile", "label": "Make", "extensions": ["make"] },


### PR DESCRIPTION
Racket is technically different than lisp, but it would be great if lisp highlighting is used until there is a separate Racket highlighting.
