### PR TITLE
Changed message object

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -2,19 +2,18 @@ define([
     "command",
     "settings!api"
   ], function(command, Settings) {
-  
+
   //handles sending custom messages based on Caret commands (builds, plugins, etc)
   var targets = Settings.get("api");
   command.on("init:restart", function() {
     targets = Settings.get("api");
   });
-  
+
   command.on("api:execute", function(id, c) {
     if (!id in targets) return c();
     var config = targets[id];
-    var message = Object.create(config.message);
     var send = function() {
-      chrome.runtime.sendMessage(config.id, message, null, function() {
+      chrome.runtime.sendMessage(config.id, config.message, null, function() {
         if (chrome.runtime.lastError) {
           console.error(chrome.runtime.lastError);
         }
@@ -35,7 +34,7 @@ define([
       send();
     }
   });
-  
+
   //External apps can send messages by matching Caret's command/argument config objects
   chrome.runtime.onMessageExternal.addListener(function(message, sender, c) {
     command.fire(message.command, message.argument, c);


### PR DESCRIPTION
While trying to get a demo plugin working that sends a message from Caret to an external plugin, I could only get Caret to send an empty object. So I went into api.json and made a couple small changes. I got rid of the `Object.create` line where the message variable is created, and replaced the single usage of the message variable with `config.message`. This makes Caret send the object specified in the External Commands file properly, rather than sending an empty one.

Here is the demo plugin I've created which will work with these changes: https://github.com/pigeontech/CaretPluginDemo