### PR TITLE
Remove file ext from default file.

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -27,7 +27,7 @@ define([
     if (file) {
       this.setFile(file);
     } else {
-      this.fileName = "untitled.txt";
+      this.fileName = "untitled";
     }
     
     this.modified = false;


### PR DESCRIPTION
This is more in line with other text editors such as Atom and Sublime.

Tested on
- `OS X 10.10.2` `Chrome 41.0.2272.76`
- `Samsung Chromebook 2` `Chrome 40.0.2214.115`