### PR TITLE
Fix #364 - autosave only saves changed tabs

### DIFF
--- a/js/sessions/autosave.js
+++ b/js/sessions/autosave.js
@@ -20,7 +20,7 @@ define([
   var autosave = function() {
     status.toast(i18n.get("fileAutosaving"));
     state.tabs.forEach(function(tab) {
-      if (tab.file && !tab.file.virtual) {
+      if (tab.file && !tab.file.virtual && tab.modified) {
         tab.save();
       }
     });


### PR DESCRIPTION
NB - made the change in Caret, it removed the trailing spaces