### PR TITLE
Enabled JSX support

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -65,6 +65,7 @@
     { "name": "java", "label": "Java", "extensions": ["java", "groovy"] },
     { "name": "javascript", "label": "JavaScript", "extensions": ["js"] },
     { "name": "json", "label": "JSON", "extensions": ["json", "caret-project"] },
+    { "name": "jsx", "label": "JSX", "extensions": ["jsx"] },
     { "name": "julia", "label": "Julia", "extensions": [] },
     { "name": "latex", "label": "LaTeX", "extensions": [] },
     { "name": "less", "label": "LESS", "extensions": ["less"] },

--- a/manifest.json
+++ b/manifest.json
@@ -87,6 +87,7 @@
         "java",
         "js",
         "json",
+        "jsx",
         "ksh",
         "less",
         "lisp",


### PR DESCRIPTION
It looks like this one line is all that's needed to enable JSX support for all those devs using React.

The syntax highlighting is more visible in some themes than others (compare chrome to monokai), but it definitely seems to work.