### PR TITLE
Add maze mode to ace config

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -78,6 +78,7 @@
     { "name": "markdown", "label": "Markdown", "extensions": ["md", "markdown"] },
     { "name": "mask", "label": "Mask", "extensions": ["mask"] },
     { "name": "matlab", "label": "MATLAB", "extensions": ["m", "mat"] },
+    { "name": "maze", "label": "Maze", "extensions": ["mz"] },
     { "name": "mysql", "label": "MySQL", "extensions": ["sql"] },
     { "name": "objectivec", "label": "Objective C", "extensions": ["obc"] },
     { "name": "perl", "label": "Perl", "extensions": ["pl", "cgi", "pm"] },


### PR DESCRIPTION
Syntax highlighting for [Maze](http://esolangs.org/wiki/Maze) has been added into Ace.
No need to merge until a new version of Ace has been released and merged into Caret.