### PR TITLE
Blue-grey links and buttons in dialogs (fixes #427)

### DIFF
--- a/css/dialog.less
+++ b/css/dialog.less
@@ -39,7 +39,7 @@
       min-width: 75px;
       margin: 0 8px;
       text-transform: uppercase;
-      color: @accent;
+      color: #455A64;
 
       &:hover {
         background: #EEE;
@@ -90,7 +90,7 @@
   }
 
   a, a:visited {
-    color: @accent;
+    color: #455A64;
   }
 
   ul {


### PR DESCRIPTION
I settled for Material blue-grey 700. Here's how it looks:
![image](https://cloud.githubusercontent.com/assets/8205055/9472377/8e18b5d6-4b72-11e5-9828-821cd8bfd583.png)