### PR TITLE
Add Powershell file extensions

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -84,7 +84,7 @@
     { "name": "php", "label": "PHP", "extensions": ["php"] },
     { "name": "pgsql", "label": "PostgreSQL", "extensions": ["sql"] },
     { "name": "plain_text", "label": "Plain Text", "extensions": ["txt", "conf", "csv", "me", "tsv", "text"] },
-    { "name": "powershell", "label": "Powershell", "extensions": ["ps"] },
+    { "name": "powershell", "label": "Powershell", "extensions": ["ps", "ps1", "psd1", "psm1", "ps1xml", "clixml", "psc1", "pssc"] },
     { "name": "python", "label": "Python", "extensions": ["py"] },
     { "name": "r", "label": "R", "extensions": ["r"] },
     { "name": "ruby", "label": "Ruby", "extensions": ["rb", "erb", "rake"] },


### PR DESCRIPTION
Add file extensions to the powershell mode in `ace.json` to be up-to-date with current powershell file types and DSC `mof` files.  

The `clixml`, `psc1`, and `pssc` powershell extensions are less-used but the `ps*1*` file extensions are extremely common.  See [here](https://en.wikipedia.org/wiki/Windows_PowerShell#File_extensions) for the extensions as listed on wiki.

This is a duplicate of `Add Powershell file extensions to ace.json #433` which I could not properly update due to my own lack of expertise. I apologize for the inconvenience.