### PR TITLE
Recognize Arduino files (extension .ino) as C++

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -42,7 +42,7 @@
     { "name": "asciidoc", "label": "AsciiDoc", "extensions": ["asciidoc", "adoc", "asc"] },
     { "name": "batchfile", "label": "Batch File", "extensions": ["bat", "cmd"] },
     { "name": "sh", "label": "Bash Shell", "extensions": ["sh", "ksh", "zsh"] },
-    { "name": "c_cpp", "label": "C/C++", "extensions": ["c", "cpp", "h", "cc"] },
+    { "name": "c_cpp", "label": "C/C++", "extensions": ["c", "cpp", "h", "cc", "ino"] },
     { "name": "clojure", "label": "Clojure", "extensions": ["clj"] },
     { "name": "coffee", "label": "CoffeeScript", "extensions": ["coffee"] },
     { "name": "coldfusion", "label": "ColdFusion", "extensions": ["cfm", "cfc", "do"] },


### PR DESCRIPTION
Arduino's language is basically just a subset of C++. I don't think it needs it's own mode, but this will at least save us from changing the syntax every time we open a .ino file.