### PR TITLE
Read-only search tabs, cb() from openFile, bug fix

### DIFF
--- a/js/sessions/switching.js
+++ b/js/sessions/switching.js
@@ -12,6 +12,7 @@ define([
       
   var raiseTab = function(tab) {
     editor.setSession(tab);
+    editor.setReadOnly(tab.readOnly);
     command.fire("session:syntax");
     command.fire("session:render");
     editor.focus();

--- a/js/tab.js
+++ b/js/tab.js
@@ -42,7 +42,7 @@ define([
     });
     
     this.animationClass = "enter";
-    
+    this.readOnly = false;
   };
   
   //hopefully this never screws up unaugmented Ace sessions.

--- a/js/ui/projectManager.js
+++ b/js/ui/projectManager.js
@@ -344,7 +344,7 @@ define([
       });
     },
     
-    openFile: function(path) {
+    openFile: function(path, c) {
       var self = this;
       var found = false;
       var node = this.pathMap[path];
@@ -370,10 +370,18 @@ define([
           },
           //if no match found, create a tab
           function() {
-            if (found) return;
+            if (found) {
+              if (c) {
+                c();
+              }
+              return;
+            }
             var file = new File(node.entry);
             file.read(function(err, data) {
               sessions.addFile(data, file);
+              if (c) {
+                c();
+              }
             });
           }
         );


### PR DESCRIPTION
These are the changes I made when making search results clickable, other than the parts that make search results clickable. You will more than likely want them in the implementation that you go with.
Adds:
* Read-only search tabs
* Bug fix: making search results stop exactly on limit
* Optional callback from project.openFile
* Restructure searchbar.js to be a little more organized with less duplicate code

