### PR TITLE
Added phtml files to use PHP syntax highlighting

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -83,7 +83,7 @@
     { "name": "mysql", "label": "MySQL", "extensions": ["sql"] },
     { "name": "objectivec", "label": "Objective C", "extensions": ["obc"] },
     { "name": "perl", "label": "Perl", "extensions": ["pl", "cgi", "pm"] },
-    { "name": "php", "label": "PHP", "extensions": ["php"] },
+    { "name": "php", "label": "PHP", "extensions": ["php", "phtml"] },
     { "name": "pgsql", "label": "PostgreSQL", "extensions": ["sql"] },
     { "name": "plain_text", "label": "Plain Text", "extensions": ["txt", "conf", "csv", "me", "tsv", "text"] },
     { "name": "powershell", "label": "Powershell", "extensions": ["ps", "ps1", "psd1", "psm1", "ps1xml", "clixml", "psc1", "pssc"] },

--- a/manifest.json
+++ b/manifest.json
@@ -120,6 +120,7 @@
         "pde",
         "pem",
         "php",
+        "phtml",
         "pkb",
         "pkg",
         "pks",


### PR DESCRIPTION
<a href="https://magento.com/">Magento</a> uses files with a .phtml extension, and these weren't included in the syntax highlighting. I added them to the PHP mode since they often contain quite a bit of it. 