### PR TITLE
Add search results highlighting

### DIFF
--- a/css/searchbar.less
+++ b/css/searchbar.less
@@ -72,7 +72,12 @@
   cursor: pointer;
 
   &:hover {
+    &:extend(.caret-search-term);
+  }
+}
+
+.caret-search-term {
+    position: absolute;
     outline: 1px solid @accent;
     background: rgba(128, 128, 128, .3);
-  }
 }

--- a/js/ui/searchbar.js
+++ b/js/ui/searchbar.js
@@ -269,8 +269,15 @@ define([
       //add the clickable marker if flagged
       if (link) {
         var range = new Range(insertRow - 1, 0, insertRow - 1, text.length);
-        resultsTab.addMarker(range, "caret-search-marker " + text, "text", true);
+        resultsTab.addMarker(range, "caret-search-marker", "text", true);
         resultsTab.links[insertRow] = link;
+      }
+      var query = this.currentSearch.searchQuery;
+      if (text.match(query)) {
+        while (match = query.exec(text)) {
+          var range = new Range(insertRow - 1, match.index, insertRow - 1, query.lastIndex);
+          resultsTab.addMarker(range, "caret-search-term", "text", true);
+        }
       }
     },
 

--- a/js/ui/searchbar.js
+++ b/js/ui/searchbar.js
@@ -211,7 +211,7 @@ define([
 
               if (firstFindInFile) { // only add a filename if it is the first result for the file
                 self.appendToResults(""); // add an extra blank line
-                self.appendToResults(path, path);
+                self.appendToResults(path + ":", path);
                 firstFindInFile = false;
               } else if (!printedLines[i] && !printedLines[i-1] && !printedLines[i-2]) { // add break if immediately previous lines not included
                 self.appendToResults("...");
@@ -248,6 +248,7 @@ define([
       resultsTab.readOnly = true;
       resultsTab.links = {};
       editor.setReadOnly(true);
+      command.fire("session:syntax", "c9search");
 
       return resultsTab;
     },


### PR DESCRIPTION
Fixes #467 using the cloud9 search results ace mode, with a minor alteration to Caret's search results output.
Also adds highlighting for the search term in the search results.