### PR TITLE
Feature / enable editor live autocomplete

### DIFF
--- a/config/user.json
+++ b/config/user.json
@@ -64,6 +64,8 @@
   "useWorker": true,
   //autocomplete triggers on Ctrl-Space
   "autocomplete": true,
+  //autocomplete triggers automatically
+  "autocompleteLive": false,
   //"Behaviors" are the auto-paired quotes and HTML tags in the editor
   "disableBehaviors": false,
 

--- a/js/editor.js
+++ b/js/editor.js
@@ -52,7 +52,8 @@ define([
     defaultFontSize();
     ace.config.loadModule("ace/ext/language_tools", function() {
       editor.setOptions({
-        enableBasicAutocompletion: userConfig.autocomplete
+        enableBasicAutocompletion: userConfig.autocomplete || false,
+        enableLiveAutocompletion: userConfig.autocompleteLive || false
       });
     });
   };


### PR DESCRIPTION
This enables live autocompletion via user setting `autocompleteLive` (means that auto complete window will appear automatically as the user is typing instead of having to press _ctrl+space_)

The feature is already present in Ace editor, so just giving an ability to enable it via config.