### PR TITLE
Fix #553

### DIFF
--- a/config/user.json
+++ b/config/user.json
@@ -89,7 +89,9 @@
 
   //Wildly eccentric? You might like Vim keybindings.
   "emulateVim": false,
-
+  
+  //jsHint settings are applied on opening a JS file
+  "jsHint": {},
   //Whether to show the "New file" tab button on the tab bar;
   "showNewTabButton": false
 }

--- a/js/tab.js
+++ b/js/tab.js
@@ -177,6 +177,8 @@ define([
     // call the superclass method to start worker
     EditSession.prototype.$startWorker.call(this);
     
+    this.detectSyntax(userConfig);
+    
     // configure jsHint worker if applicable
     if (this.syntaxMode === 'javascript' && userConfig.jsHint && this.$worker) {
       this.$worker.send('changeOptions', [userConfig.jsHint]);


### PR DESCRIPTION
Fix for #553. Calls Tab#detectSyntax before attempting to check the syntaxMode when starting the service worker and checking whether to use custom jsHint settings. Adds jsHint option to the user config file.