### PR TITLE
Adds user setting for showing upgrade notification

### DIFF
--- a/background.js
+++ b/background.js
@@ -104,7 +104,7 @@ chrome.contextMenus.create({
   if (chrome.runtime.lastError) console.log(chrome.runtime.lastError);
 });
 
-var emergencyReset = function() {
+var emergencyReset = function(callback) {
   if (mainWindow) mainWindow.close();
   var cleared = {
     local: false,
@@ -118,7 +118,9 @@ var emergencyReset = function() {
         iconUrl: "icon-128.png",
         title: "Emergency Reset Complete",
         message: "Caret has been reset to the default settings."
-      }, function() {});
+      }, function() {
+        if (callback) callback();
+      });
     }
   };
   chrome.storage.local.clear(check.bind(null, "local"));

--- a/background.js
+++ b/background.js
@@ -104,27 +104,28 @@ chrome.contextMenus.create({
   if (chrome.runtime.lastError) console.log(chrome.runtime.lastError);
 });
 
-var emergencyReset = function(callback) {
+var emergencyReset = async function() {
   if (mainWindow) mainWindow.close();
   var cleared = {
     local: false,
     sync: false
   };
-  var check = function(storage) {
-    cleared[storage] = true;
-    if (cleared.local && cleared.sync) {
-      chrome.notifications.create("app:factory-reset-complete", {
-        type: "basic",
-        iconUrl: "icon-128.png",
-        title: "Emergency Reset Complete",
-        message: "Caret has been reset to the default settings."
-      }, function() {
-        if (callback) callback();
-      });
-    }
-  };
-  chrome.storage.local.clear(check.bind(null, "local"));
-  chrome.storage.sync.clear(check.bind(null, "sync"));
+  var clear = function(storage) {
+    return new Promise(function(resolve, reject) {
+      storage.clear(resolve);
+    });
+  }
+  var showNotification = new Promise(function(resolve, reject) {
+    chrome.notifications.create("app:factory-reset-complete", {
+      type: "basic",
+      iconUrl: "icon-128.png",
+      title: "Emergency Reset Complete",
+      message: "Caret has been reset to the default settings."
+    }, resolve);
+  });
+  await clear(chrome.storage.local)
+    .then(clear(chrome.storage.sync))
+    .then(showNotification);
 };
 
 chrome.contextMenus.onClicked.addListener(function(data) {

--- a/config/user.json
+++ b/config/user.json
@@ -2,6 +2,9 @@
   //If you want to disable update checks at startup, change this
   "promptForUpdates": true,
 
+  // One of "realtime", "active" (notify when Caret is open), or "silent".
+  "notifyOnUpdates": "realtime",
+
   "defaultTheme": "chrome", //This should be any of the supported Ace themes
   /*
   Ace theme names are usually underscored, lowercase versions of the "friendly" names:

--- a/js/storage/settingsProvider.js
+++ b/js/storage/settingsProvider.js
@@ -173,7 +173,8 @@ define([
     if (index !== 0) return;
     await chromeP.notifications.clear("settings:emergency-reset-confirm");
     var page = await chromeP.runtime.getBackgroundPage();
-    page.emergencyReset(exportLocalSettings);
+    await page.emergencyReset();
+    await exportLocalSettings();
   });
 
   return Settings;

--- a/js/storage/settingsProvider.js
+++ b/js/storage/settingsProvider.js
@@ -39,6 +39,14 @@ define([
     return cloneObject(item);
   };
   
+  //export certain settings to Chrome local storage that need to be accessed by background page
+  var exportLocalSettings = async function() {
+    var userSettings = Settings.get("user");
+    await chromeP.storage.local.set({
+      "notifyOnUpdates": userSettings.notifyOnUpdates,
+    });
+  }
+  
   //track transfers to prevent multiple requests
   var pending = {};
 
@@ -141,6 +149,7 @@ define([
     local = {};
     var completed = keys.map(k => Settings.load(k));
     await Promise.all(completed);
+    await exportLocalSettings();
     command.fire("init:restart");
   });
   
@@ -164,7 +173,7 @@ define([
     if (index !== 0) return;
     await chromeP.notifications.clear("settings:emergency-reset-confirm");
     var page = await chromeP.runtime.getBackgroundPage();
-    page.emergencyReset();
+    page.emergencyReset(exportLocalSettings);
   });
 
   return Settings;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Caret",
   "description": "Professional text editing for Chrome and Chrome OS",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "manifest_version": 2,
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
Tested locally with all three values of `notifyOnUpdates`, with Caret running/stopped. Did an emergency reset from the help menu and it looks error-less.

Adds `pendingUpgradeNotification` and `notifyOnUpdates` keys to Chrome local storage. Adds `notifyOnUpdates` key to user settings.