### PR TITLE
Remove notification on auto-upgrade

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -121,8 +121,6 @@
   "notificationNoUpdateDetail": { "message": "There aren't any updates for Caret at this time." },
   "notificationUpdateOK": { "message": "Yes, update and restart" },
   "notificationUpdateWait": { "message": "No thanks" },
-  "notificationUpdated": { "message": "Caret has been updated" },
-  "notificationUpdatedDetail": { "message": "Now at version $1. Click to see the changelog." },
 
   "searchDisplayQuery": { "message": "Searching for: $1\n" },
   "searchTabName": { "message": "Results: $1" },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -11,6 +11,9 @@
   "aboutSupport": {
     "message": "Support"
   },
+  "aboutChangelog": {
+    "message": "Changelog"
+  },
   "aboutLicense": {
     "message": "Caret is available under a GPL license, which means that the <a href=\"https://github.com/thomaswilburn/Caret\" target=_blank>source code</a> is freely available for you to use and modify as you see fit. If you find Caret useful, consider donating to the Free Software Foundation's <a href=\"http://endsoftwarepatents.org/donate\" target=_blank>Fund to End Software Patents</a>."
   },

--- a/installer.js
+++ b/installer.js
@@ -1,5 +1,3 @@
-var notification = "upgraded";
-
 chrome.runtime.onInstalled.addListener(function(e) {
   //this is where we'll track upgrades
   if (!e.previousVersion) return;
@@ -11,15 +9,8 @@ chrome.runtime.onInstalled.addListener(function(e) {
   var minor = semver[1];
   var build = semver[2];
   
-  if (e.previousVersion != manifest.version) {
-    //let the user know
-    chrome.notifications.create(notification, {
-      type: "basic",
-      iconUrl: "icon-128.png",
-      title: chrome.i18n.getMessage("notificationUpdated"),
-      message: chrome.i18n.getMessage("notificationUpdatedDetail", [manifest.version]),
-      isClickable: true
-    }, function(id) { notification = id });
+  if (e.previousVersion == manifest.version) {
+    return;
   }
   
   // console.log("Upgrading Caret from version " + e.previousVersion);
@@ -30,10 +21,4 @@ chrome.runtime.onInstalled.addListener(function(e) {
   
   */
 
-});
-
-
-chrome.notifications.onClicked.addListener(function(id) {
-  if (id != notification) return;
-  window.open("https://github.com/thomaswilburn/Caret/blob/master/changelog.rst", "target=_blank");
 });

--- a/templates/about.html
+++ b/templates/about.html
@@ -6,6 +6,8 @@
       <a href="http://thomaswilburn.net/caret" target=_blank>[ __MSG_aboutHomePage__ ]</a>
       &mdash;
       <a href="https://chrome.google.com/webstore/detail/caret/fljalecfjciodhpcledpamjachpmelml/support" target=_blank>[ __MSG_aboutSupport__ ]</a>
+      &mdash;
+      <a href="https://github.com/thomaswilburn/Caret/blob/master/changelog.rst" target=_blank>[ __MSG_aboutChangelog__ ]</a>
     <li>__MSG_aboutLicense__
   </ul>
 </span></div>


### PR DESCRIPTION
Caret currently displays a notification every time the app is upgraded. This is discouraged by the [MD guidelines](https://material.io/guidelines/patterns/notifications.html#notifications-usage) because it unnecessarily annoys users.

(A butterbar inside the app might be a better choice than a systemwide notification.)