### PR TITLE
Changed sendMessageExternal to sendMessage

### DIFF
--- a/config/api.json
+++ b/config/api.json
@@ -2,7 +2,7 @@
   "sampleMessage": {
     "id": "extension id goes here",
     "message": {
-      "data": "message can be any JSON object passable to chrome.runtime.sendMessageExternal"
+      "data": "message can be any JSON object passable to chrome.runtime.sendMessage"
     }
   }
 }


### PR DESCRIPTION
chrome.runtime.sendMessageExternal is outdated, and has been replaced be chrome.runtime.sendMessage

Addresses issue #635 
(unsure if this is the only place it's used, however I can only assume it is)