### PR TITLE
Support simple syntax highlighting for .vue files

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -81,7 +81,7 @@
     { "name": "handlebars", "label": "Handlebars", "extensions": ["handlebars", "hbs", "tpl", "mustache"] },
     { "name": "haskell", "label": "Haskell", "extensions": ["hs"] },
     { "name": "haxe", "label": "haXe", "extensions": ["haxe", "hx"] },
-    { "name": "html", "label": "HTML", "extensions": ["html", "htm", "htmls", "shtml", "ctp", "xhtml"] },
+    { "name": "html", "label": "HTML", "extensions": ["html", "htm", "htmls", "shtml", "ctp", "xhtml", "vue"] },
     { "name": "ini", "label": "Windows INI", "extensions": ["ini", "cfg", "prefs"] },
     { "name": "io", "label": "Io", "extensions": ["io"] },
     { "name": "jack", "label": "Jack", "extensions": ["jack"] },


### PR DESCRIPTION
Currently, .vue files (used for Vue.js components) do not have syntax highlighting. After doing some research (https://github.com/ajaxorg/ace/issues/2841), it seems like the consensus is to use HTML syntax highlighting.