### PR TITLE
Add support for dirobium assembly files

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -45,7 +45,7 @@
     { "name": "ada", "label": "Ada", "extensions": ["adb", "ada"] },
     { "name": "apache_conf", "label": "Apache Config", "extensions": ["htaccess", "htgroups", "htpasswd", "conf"] },
     { "name": "asciidoc", "label": "AsciiDoc", "extensions": ["asciidoc", "adoc", "asc"] },
-    { "name": "assembly_x86", "label": "X86 Assembly", "extensions": ["asm"] },
+    { "name": "assembly_x86", "label": "X86 Assembly", "extensions": ["asm", "das"] },
     { "name": "autohotkey", "label": "AutoHotkey", "extensions": ["ahk"] },
     { "name": "batchfile", "label": "Batch File", "extensions": ["bat", "cmd"] },
     { "name": "c_cpp", "label": "C/C++", "extensions": ["c", "cpp", "h", "cc", "ino", "cxx", "hh", "hpp"] },


### PR DESCRIPTION
I do all of the development work for [Dirobium](https://github.com/Ewpratten/Dirobium) and the [Dirobium assembler](https://github.com/Ewpratten/DirAS) in caret, and was disappointed that there was no syntax highlighting for my .das files. It turns out that using the x86 syntax highlighting looks great for das too, so here is my little pull request to add some color to .das files.