### PR TITLE
Enable Undo of File->Revert

### DIFF
--- a/js/fileManager.js
+++ b/js/fileManager.js
@@ -72,7 +72,7 @@ define([
     var tab = sessions.getCurrent();
     if (!tab.file) return;
     var data = await tab.file.read();
-    tab.setValue(data);
+    editor.setValue(data);
     tab.modified = false;
     tab.modifiedAt = new Date();
     sessions.renderTabs();


### PR DESCRIPTION
I did something dumb today and accidentally reverted a file, losing all my changes. I was dismayed to find that there was no way to get my changes back! So here's a simple pull request :)

[Looking at ace docs](https://ace.c9.io/#nav=howto&api=edit_session), using session.setValue() resets undo history, but editor.setValue() preserves history so that Undo will undo the revert. 

Tested and working on a local build. 