### PR TITLE
Display distinct error message for missing font.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -133,5 +133,6 @@
   "searchMatchCase": { "message": "Match Case" },
   "searchFindAll": { "message": "Find All" },
 
+  "errorMissingFont": { "message": "The font you've selected isn't available to Caret, which can only use fonts installed on your system. A default font will be used instead." },
   "errorProportionalFont": { "message": "The custom font you've selected may cause problems with Caret's editing component, which only supports monospaced fonts (where the letters are all the same width). If you experience cursor issues, please reset the fontFamily setting in your user preferences." }
 }


### PR DESCRIPTION
The commit in this pull request causes a more appropriate message to be displayed if a user-specified font is missing. Currently the proportional-font error message is display in that case, which can be confusing.

It also adds tests for font kerning and ligatures, which can get in the way of cursor positioning in the same way that proportional fonts can. See the commit message and code comments for more details.

Finally, it makes the font tests use a canvas object instead of adding a <span> element to the DOM. This is slightly simpler and should be a bit faster (though specific performance tests have not been run).

The results of the change have been tested on Chrome OS running the latest stable version of Chrome.