### PR TITLE
Add print margin column setting

### DIFF
--- a/config/user.json
+++ b/config/user.json
@@ -10,7 +10,8 @@
 
   // editor options
   "showWhitespace": false, //show whitespace characters (spaces, tabs, returns)
-  "showMargin": false,
+  "showMargin": false,//set to true to display a right margin line
+  "marginColumn": false, //where to display the margin line or false to use wrapLimit or 80
   "scrollPastEnd": true, //allow the editor to scroll past the end of the document
   "trimTrailingWhitespace": true, //run "Trim Trailing Whitespace" on save
   "trimEmptyLines": false, //should the trim whitespace command also truncate empty lines?
@@ -19,7 +20,7 @@
   "indentation": 2, //indentation size
   "useTabs": false, //will turn off Ace's setUseSoftTabs() option and use tab characters instead
   "wordWrap": true,
-  "wrapLimit": false, //Set to the number of characters you want or false for full window
+  "wrapLimit": false, //set to the number of characters you want or false for full window
   "lineEndings": "auto", //newline format - "windows", "unix", or "auto"
 
   //only fixed-width fonts supported, for now

--- a/js/editor.js
+++ b/js/editor.js
@@ -47,7 +47,7 @@ define([
     });
     editor.setBehavioursEnabled(!userConfig.disableBehaviors);
     editor.setShowPrintMargin(userConfig.showMargin || false);
-    editor.setPrintMarginColumn(userConfig.wrapLimit || 80);
+    editor.setPrintMarginColumn(userConfig.marginColumn || userConfig.wrapLimit || 80);
     editor.setShowInvisibles(userConfig.showWhitespace || false);
     editor.setHighlightActiveLine(userConfig.highlightLine || false);
     


### PR DESCRIPTION
The commit in this pull request allows a print margin to be displayed at a position other than the the wrap limit column, or to display a print margin at a position other than 80 when the full-window wrapping is selected.

For example it allows a print margin at column 100 with full-window wrapping, or a print margin at column 80 with a wrap limit of 100 characters.

See the commit message and the code for more details.