### PR TITLE
Provide option to reveal in sidebar in tab context menu

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -139,6 +139,7 @@
 
   "tabClose": { "message": "Close" },
   "tabCloseRight": { "message": "Close tabs to the right" },
-  "tabCopyPath": { "message": "Copy file path" }
+  "tabCopyPath": { "message": "Copy file path" },
+  "tabRevealInSideBar": { "message": "Reveal in side bar" }
 
 }

--- a/js/sessions/binding.js
+++ b/js/sessions/binding.js
@@ -134,6 +134,7 @@ define([
   contextMenus.register(i18n.get("tabClose"), "closeTab", "tabs/:id", args => command.fire("session:close-tab", args.id));
   contextMenus.register(i18n.get("tabCloseRight"), "closeTabsRight", "tabs/:id", args => closeTabsRight(args.id));
   contextMenus.register(i18n.get("tabCopyPath"), "copyFilePath", "tabs/:id", args => copyFilePath(args.id));
+  contextMenus.register(i18n.get("tabRevealInSideBar"), "revealInSideBar", "tabs/:id", args => command.fire("session:reveal-in-side-bar", args));
 
   return function() {
     enableTabDragDrop();


### PR DESCRIPTION
Adds a new option in the tab context menu to reveal the file in the side bar. This is achieved by traversing the directories tree, generating the list of directories above the selected file and adding these to the `expanded` hash. The side bar is then re-rendered. 

New context menu option | After option selection
--- | ---
![screenshot 2019-02-17 at 14 04 10](https://user-images.githubusercontent.com/635903/52914191-69fe6c00-32bd-11e9-826e-b582007b8a78.png) | ![screenshot 2019-02-17 at 14 04 31](https://user-images.githubusercontent.com/635903/52914193-6e2a8980-32bd-11e9-9c1f-3408f29b56f7.png)
