### PR TITLE
Handle error in FileSystemFileEntry.file when reading

### DIFF
--- a/js/storage/file.js
+++ b/js/storage/file.js
@@ -48,6 +48,9 @@ define([
         };
         self.entry.file(function(f) {
           reader.readAsText(f);
+        }, function(err) {
+          console.error("File read error!");
+          fail(err);
         });
       });
     },


### PR DESCRIPTION
Handles the case where the file no longer exists
when opening the app and restoring files.  E.g. file
may be from a removable device.