### PR TITLE
Add "you may need to restart" message to user.json

### DIFF
--- a/config/user.json
+++ b/config/user.json
@@ -63,7 +63,7 @@
   //Wildly eccentric? You might like Vim keybindings.
   "emulateVim": false,
   
-  //jsHint settings are applied on opening a JS file
+  //jsHint settings are applied on opening a JS file. You may need to restart Caret for changes to take effect.
   "jsHint": {},
 
   // You can set syntax options here. Not all options supported yet.


### PR DESCRIPTION
This is a very very small PR but hopefully it will save someone else some time.

I found that after changing the `jsHint` options in `user.json`, I had to restart the editor (which I didn't have to do for any of the other config options in `user.json`). It took me twenty minutes to figure this out, so I added a comment in `user.json` warning users to restart the editor after changing the jsHint options:

    //jsHint settings are applied on opening a JS file. You may need to restart Caret for changes to take effect.

Thanks for the awesome editor, by the way! I've been looking for something like this for a very long time. I hope to contribute more in the future!