### PR TITLE
Fixed the misused negation operator.

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -10,7 +10,7 @@ define([
   command.on("init:restart", () => targets = Settings.get("api"));
 
   command.on("api:execute", async function(id, c = noop) {
-    if (!id in targets) return c();
+    if (!( id in targets )) return c();
     var config = targets[id];
     var message = {};
     //shallow-copy config message, just in case


### PR DESCRIPTION
  * As operator precedence, "!id in targets" means "(!id) in targets"
    * refs : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence
  * Fixed to "!( id in targets )"