### PR TITLE
Enable TSX language mode

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -130,7 +130,7 @@
   "searchTabName": { "message": "Ergebnisse: $1" },
   "searchNoDirectories": { "message": "\nKeine Dateien durchsucht. Dem Projekt muß zuerst ein Verzeichnis hinzufügt werden." },
   "searchSummary": { "message": "\n\n$1 Treffer gefunden. $2 Dateien durchsucht." },
-  "searchCancelled": { "message": "\nSuche wurde abgebrochen. Die Höchstzahl an zulässigen Suchergebnissen kann in den Benutzereinstellungen geändert werden." }
+  "searchCancelled": { "message": "\nSuche wurde abgebrochen. Die Höchstzahl an zulässigen Suchergebnissen kann in den Benutzereinstellungen geändert werden." },
   "searchMatchCase": { "message": "Schreibweise vergleichen" },
   "searchFindAll": { "message": "Finde alle" },
 

--- a/config/ace.json
+++ b/config/ace.json
@@ -152,6 +152,7 @@
     { "name": "tex", "label": "TeX", "extensions": ["tex"] },
     { "name": "textile", "label": "Textile", "extensions": ["textile"] },
     { "name": "toml", "label": "Toml", "extensions": ["toml"] },
+    { "name": "tsx", "label": "TSX", "extensions": ["tsx"] },
     { "name": "twig", "label": "Twig", "extensions": ["twig"] },
     { "name": "typescript", "label": "TypeScript", "extensions": ["ts", "typescript", "str"] },
     { "name": "vala", "label": "Vala", "extensions": ["vala"] },


### PR DESCRIPTION
TSX is available in Ace, but was not enabled. I enabled it and fixed a small error in the de locale that was preventing loading the extension (bad json, was missing a comma).