### PR TITLE
Added .nim syntax

### DIFF
--- a/config/ace.json
+++ b/config/ace.json
@@ -111,6 +111,7 @@
     { "name": "mel", "label": "MEL", "extensions": ["mel"] },
     { "name": "mushcode", "label": "MUSHCode", "extensions": ["mc", "mush"] },
     { "name": "mysql", "label": "MySQL", "extensions": ["sql", "mysql"] },
+    { "name": "nim", "label": "Nim", "extensions": ["nim", "nims"] },
     { "name": "nix", "label": "Nix", "extensions": ["nix"] },
     { "name": "objectivec", "label": "Objective-C", "extensions": ["obc", "m", "mm"] },
     { "name": "ocaml", "label": "OCaml", "extensions": ["ml", "mli"] },


### PR DESCRIPTION
Both .nim and .nims file formats were not included in Caret, but are supported by Ace so I added both of them.